### PR TITLE
Remove Native TLS build step from workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,11 +40,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rustup_toolchain }}
 
-      - name: Cargo build (Native TLS)
-        run: |
-          cargo build --all 
-          cargo clean
-
       - name: Cargo build (Rust TLS)
         run: cargo build --all
 


### PR DESCRIPTION
Removed the Cargo build step for Native TLS from the workflow.

fix #19