### PR TITLE
feat: integrate shadow-rs for build-time information #100

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ normal = ["ctor"]
 # ===========================================================================
 
 [build-dependencies]
-shadow-rs =  "1.5"
+shadow-rs = "1.5"
 
 # ===========================================================================
 # Dev Dependencies
@@ -108,13 +108,13 @@ community = [
 ]
 
 # --- Connectors (via wp_connectors) ---
-kafka         = ["wp-connectors/kafka"]
-mysql         = ["wp-connectors/mysql"]
-doris         = ["wp-connectors/doris"]
-clickhouse    = ["wp-connectors/clickhouse"]
+kafka = ["wp-connectors/kafka"]
+mysql = ["wp-connectors/mysql"]
+doris = ["wp-connectors/doris"]
+clickhouse = ["wp-connectors/clickhouse"]
 elasticsearch = ["wp-connectors/elasticsearch"]
-prometheus    = ["wp-connectors/prometheus"]
-victorialogs   = ["wp-connectors/victorialogs"]
+prometheus = ["wp-connectors/prometheus"]
+victorialogs = ["wp-connectors/victorialogs"]
 victoriametrics = ["wp-connectors/victoriametrics"]
 
 # --- Enterprise ---
@@ -123,19 +123,19 @@ victoriametrics = ["wp-connectors/victoriametrics"]
 all = ["community"]
 
 # --- Testing (cfg gates) ---
-sys_test        = []
+sys_test = []
 res_depend_test = []
 
 # --- Development ---
-examples  = []
-perf-ci   = []
+examples = []
+perf-ci = []
 dev-tools = []
 wp-enterprise = []
 
 # --- Plugins (placeholder for compatibility) ---
 example-plugin = []
-extras         = []
-plugin-suite   = []
+extras = []
+plugin-suite = []
 
 # ===========================================================================
 # Dependencies
@@ -170,7 +170,7 @@ anyhow = "1.0"
 thiserror = "2.0"
 orion-error = "0.5"
 orion-sec = "0.3"
-orion-variate= "0.10"
+orion-variate = "0.10"
 orion_conf = { version = "0.4", features = ["yaml", "toml"] }
 
 # --- Time ---
@@ -203,7 +203,7 @@ lazy_static = "1.5"
 contracts = "0.6"
 ctor = "0.6"
 hex = "0.4"
-shadow-rs = "1.5"
+shadow-rs = { version = "1.5.0", default-features = false }
 rand = "0.9"
 
 # --- Data Structures ---
@@ -216,24 +216,24 @@ glob = "0.3"
 
 # --- Internal: Open API ---
 
-wp-connector-api =  "0.7"
-wp-parse-api     =  "0.7"
-wp-model-core    =  "0.7"
+wp-connector-api = "0.7"
+wp-parse-api = "0.7"
+wp-model-core = "0.7"
 
 # --- Internal: Infrastructure ---
-wp-log       =  "0.1"
-wp-error     =  "0.7"
-wp-specs     =  "0.7"
-wp-conf-base =  "0.1"
-wp-data-fmt  =  "0.1"
+wp-log = "0.1"
+wp-error = "0.7"
+wp-specs = "0.7"
+wp-conf-base = "0.1"
+wp-data-fmt = "0.1"
 
 # --- Internal: Engine ---
-wp-engine     = {                            git = "https://github.com/wp-labs/wp-engine", tag = "v1.8.2-beta" }
-wp_conf       = { package = "wp-config",     git = "https://github.com/wp-labs/wp-engine", tag = "v1.8.2-beta" }
-wpl           = { package = "wp-lang",       git = "https://github.com/wp-labs/wp-engine", tag = "v1.8.2-beta" }
-wp_knowledge  = { package = "wp-knowledge",  git = "https://github.com/wp-labs/wp-engine", tag = "v1.8.2-beta" }
-wp-cli-core   = { package = "wp-cli-core",   git = "https://github.com/wp-labs/wp-engine", tag = "v1.8.2-beta" }
-wp-proj       = { package = "wp-proj",       git = "https://github.com/wp-labs/wp-engine", tag = "v1.8.2-beta" }
+wp-engine = { git = "https://github.com/wp-labs/wp-engine", tag = "v1.8.2-beta" }
+wp_conf = { package = "wp-config", git = "https://github.com/wp-labs/wp-engine", tag = "v1.8.2-beta" }
+wpl = { package = "wp-lang", git = "https://github.com/wp-labs/wp-engine", tag = "v1.8.2-beta" }
+wp_knowledge = { package = "wp-knowledge", git = "https://github.com/wp-labs/wp-engine", tag = "v1.8.2-beta" }
+wp-cli-core = { package = "wp-cli-core", git = "https://github.com/wp-labs/wp-engine", tag = "v1.8.2-beta" }
+wp-proj = { package = "wp-proj", git = "https://github.com/wp-labs/wp-engine", tag = "v1.8.2-beta" }
 
 wp-connectors = { package = "wp-connectors", git = "https://github.com/wp-labs/wp-connectors", tag = "v0.7.5-alpha.1" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 use orion_conf::{ToStructError, UvsConfFrom};
 use orion_sec::load_sec_dict_by;
 use orion_variate::EnvDict;
+use std::sync::Once;
 use wp_error::{RunReason, RunResult};
+
+shadow_rs::shadow!(build);
 
 // Shared library module for warp-parse
 pub mod feats;
@@ -11,4 +14,18 @@ pub const WP_DOT_DIR: &str = ".warp_parse";
 pub fn load_sec_dict() -> RunResult<EnvDict> {
     load_sec_dict_by(WP_DOT_DIR, SEK_KEY_FILE, orion_sec::SecFileFmt::Toml)
         .map_err(|e| RunReason::from_conf(format!("{}", e)).to_err())
+}
+
+pub fn log_build_info_once() {
+    static BUILD_INFO_ONCE: Once = Once::new();
+    BUILD_INFO_ONCE.call_once(|| {
+        wp_log::info_ctrl!(
+            "version {} (branch {}, commit {}, built {} via {})",
+            build::PKG_VERSION,
+            build::BRANCH,
+            build::SHORT_COMMIT,
+            build::BUILD_TIME_3339,
+            build::RUST_VERSION,
+        );
+    });
 }

--- a/src/wparse/cli.rs
+++ b/src/wparse/cli.rs
@@ -1,11 +1,12 @@
 use clap::{Args, Parser};
+use warp_parse::build::CLAP_LONG_VERSION;
 use wp_error::error_handling::RobustnessMode;
 
 /// Local CLI definition so we can control metadata/version independently.
 #[derive(Parser)]
 #[command(
     name = "wparse",
-    version = env!("CARGO_PKG_VERSION"),
+    version = CLAP_LONG_VERSION,
     about = "Warp Parse CLI"
 )]
 pub enum WParseCLI {

--- a/src/wparse/main.rs
+++ b/src/wparse/main.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::sync::Once;
 // 全局分配器：在非 Windows 平台启用 jemalloc，提升多线程分配性能
 
 //use tikv_jemallocator::Jemalloc;
@@ -10,30 +9,16 @@ use std::sync::Once;
 use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
-use shadow_rs::shadow;
-shadow!(build);
 use clap::Parser;
 
-use warp_parse::load_sec_dict;
+use warp_parse::{load_sec_dict, log_build_info_once};
 
 use wp_cli_core::split_quiet_args;
 use wp_engine::facade::diagnostics::{exit_code_for, print_run_error};
 use wp_engine::facade::WpApp;
 use wp_error::run_error::RunResult;
 mod cli;
-static BUILD_INFO_ONCE: Once = Once::new();
-fn log_build_info_once() {
-    BUILD_INFO_ONCE.call_once(|| {
-        wp_log::info_ctrl!(
-            "wparse version {} (branch {}, commit {}, built {} via {})",
-            build::PKG_VERSION,
-            build::BRANCH,
-            build::SHORT_COMMIT,
-            build::BUILD_TIME_3339,
-            build::RUST_VERSION,
-        );
-    });
-}
+
 use crate::cli::WParseCLI;
 fn register_extension() {
     // Register all built-in sinks, sources, and optional connectors

--- a/src/wpgen/cli.rs
+++ b/src/wpgen/cli.rs
@@ -1,9 +1,9 @@
 use clap::{Parser, Subcommand};
-
+use warp_parse::build::CLAP_LONG_VERSION;
 #[derive(Parser, Debug)]
 #[command(
     name = "wpgen",
-    version,
+    version = CLAP_LONG_VERSION,
     about = "WarpParse generator (shim)/WarpParse 数据生成器（兼容壳）"
 )]
 pub struct Cli {

--- a/src/wproj/args.rs
+++ b/src/wproj/args.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Parser, Subcommand};
 use wp_proj::consts::{DEFAULT_ANALYSE_LINE_MAX, DEFAULT_ANALYSE_MODE, DEFAULT_WORK_ROOT};
+
+use warp_parse::build::CLAP_LONG_VERSION;
 // sinks helpers are available via facade::config
 // use wp_engine::sinks::{DebugViewer, ViewOuter}; // no longer used directly
 // use wp_conf::conf::sink::{SinkUseConf, SinksEnum}; // no longer used directly
@@ -62,7 +64,7 @@ wproj is the official CLI tool for Warp Flow Engine, providing comprehensive pro
 • Data source checking, statistics, and validation
 • Model (rules/sources/sinks) management and monitoring
 • Knowledge base (KnowDB) creation and maintenance",
-    version,
+    version = CLAP_LONG_VERSION,
     author = "Warp Flow Engine Team"
 )]
 pub struct WProjCli {


### PR DESCRIPTION
- Add shadow-rs as a build dependency
- Implement build.rs to generate shadow.rs metadata
- Update version command to display Git commit, build time, and rustc version
- Enable better traceability for deployed binaries

Closes #100