### PR TITLE
feat(labs): integrate wp-connectors-labs with dmdb connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3378,6 +3378,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "odbc-api"
+version = "24.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04f75fb2176707bce6c9180bf722346005d26df377471672e65fcb63252bf6c"
+dependencies = [
+ "atoi",
+ "log",
+ "odbc-sys",
+ "thiserror 2.0.18",
+ "widestring",
+]
+
+[[package]]
+name = "odbc-sys"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245cb4fe8236df4fd352ba96075d754233c6509d654d9f1c1482158b7d6c083d"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5871,6 +5890,7 @@ dependencies = [
  "wp-config",
  "wp-connector-api",
  "wp-connectors",
+ "wp-connectors-labs",
  "wp-engine",
  "wp-error",
  "wp-knowledge",
@@ -6054,6 +6074,12 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "wildmatch"
@@ -6703,6 +6729,31 @@ dependencies = [
  "wp-model-core",
  "wp-parse-api",
  "wp-specs",
+]
+
+[[package]]
+name = "wp-connectors-labs"
+version = "0.1.1"
+source = "git+https://github.com/wp-labs/wp-connectors-labs.git?rev=822e095#822e095e60a1e83b692256e0cfa193a3224c2c24"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "educe",
+ "log",
+ "odbc-api",
+ "orion-error",
+ "orion_conf",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "wp-conf-base",
+ "wp-connector-api",
+ "wp-error",
+ "wp-log",
+ "wp-model-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,10 +94,13 @@ core = []
 # --- Community Edition (default) ---
 community = ["core", "wp-connectors"]
 
+# --- Labs (experimental connectors) ---
+labs = ["wp-connectors-labs"]
+
 # --- Enterprise ---
 
 # --- Convenience ---
-all = ["community"]
+all = ["community", "labs"]
 
 # --- Testing (cfg gates) ---
 sys_test = []
@@ -196,6 +199,7 @@ wp-proj       = { package = "wp-proj",       git = "https://github.com/wp-labs/w
 
 wp-self-update =  "0.2"
 wp-connectors = { git = "https://github.com/wp-labs/wp-connectors", tag = "v0.13.2", optional = true }
+wp-connectors-labs = { git = "https://github.com/wp-labs/wp-connectors-labs.git", rev = "822e095", optional = true, features = ["dmdb"] }
 
 # @gxl:block(local_motor)
 #wp-engine = { path = "../wp-motor" }

--- a/src/feats.rs
+++ b/src/feats.rs
@@ -58,4 +58,13 @@ pub fn register_optional_connectors() {
         register_sink_factory(wp_connectors::http::HttpSinkFactory);
     }
 
+    #[cfg(feature = "wp-connectors-labs")]
+    {
+        use wp_engine::connectors::registry::{register_sink_factory, register_source_factory};
+
+        // Dmdb (达梦数据库, experimental)
+        register_source_factory(wp_connectors_labs::dmdb::DmdbSourceFactory);
+        register_sink_factory(wp_connectors_labs::dmdb::DmdbSinkFactory);
+    }
+
 }


### PR DESCRIPTION
Add wp-connectors-labs dependency (rev 822e095) behind `labs` feature, register DmdbSourceFactory and DmdbSinkFactory in register_optional_connectors.